### PR TITLE
Improve File Sync, Load and Add, and Clean Up

### DIFF
--- a/ARKBreedingStats/Creature.cs
+++ b/ARKBreedingStats/Creature.cs
@@ -5,7 +5,7 @@ using System.Xml.Serialization;
 namespace ARKBreedingStats
 {
     [Serializable()]
-    public class Creature
+    public class Creature : IEquatable<Creature>
     {
         public string species;
         public string name;
@@ -69,6 +69,31 @@ namespace ARKBreedingStats
             imprintingBonus = imprinting;
             this.status = CreatureStatus.Available;
             calculateLevelFound();
+        }
+
+        public bool Equals(Creature other)
+        {
+            if (other.guid == guid)
+                return true;
+            else
+                return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            Creature creatureObj = obj as Creature;
+            if (creatureObj == null)
+                return false;
+            else
+                return Equals(creatureObj);
+        }
+
+        public override int GetHashCode()
+        {
+            return guid.GetHashCode();
         }
 
         public void calculateLevelFound()

--- a/ARKBreedingStats/CreatureCollection.cs
+++ b/ARKBreedingStats/CreatureCollection.cs
@@ -35,5 +35,14 @@ namespace ARKBreedingStats
         public List<Player> players = new List<Player>();
         [XmlArray]
         public List<Tribe> tribes = new List<Tribe>();
+
+        public void mergeCreatureList(List<Creature> creaturesToMerge)
+        {
+            foreach (Creature creature in creaturesToMerge)
+            {
+                if (!creatures.Contains(creature))
+                    creatures.Add(creature);
+            }
+        }
     }
 }

--- a/ARKBreedingStats/FileSync.cs
+++ b/ARKBreedingStats/FileSync.cs
@@ -50,11 +50,11 @@ namespace ARKBreedingStats
                             break;
                     }
                 }
-                catch (FileNotFoundException ex)
+                catch (FileNotFoundException)
                 { }
-                catch (IOException ex)
+                catch (IOException)
                 { }
-                catch (UnauthorizedAccessException ex)
+                catch (UnauthorizedAccessException)
                 { }
                 Thread.Sleep(500);
             }

--- a/ARKBreedingStats/Form1.cs
+++ b/ARKBreedingStats/Form1.cs
@@ -245,7 +245,7 @@ namespace ARKBreedingStats
             }
             else
             {
-                loadCollectionFile(currentFileName);
+                loadCollectionFile(currentFileName, true);
             }
         }
 
@@ -1092,7 +1092,7 @@ namespace ARKBreedingStats
             assignCollectionClasses();
 
             if (keepCurrentCreatures)
-                creatureCollection.creatures.AddRange(oldCreatures);
+                creatureCollection.mergeCreatureList(oldCreatures);
             else
             {
                 currentFileName = fileName;


### PR DESCRIPTION
I noticed some nasty undesired behavior where if you currently have an unsaved dino in your creature list, and then the file gets updated, that dino disappears. Fixed that by adding a mergeCreatureList function as well as implementing IEquatable for creature so that we can use List<T>'s comparison functions properly. This also had the side effect of improving the load and add option so that it no longer adds duplicate dinos.

I also cleaned up some unnecessary variables in FileSync.cs to get rid of a few Visual Studio Warnings. PTAL @cadon :smile: