### PR TITLE
Address TamingControl1.speciesIndex being out of sync with other speciesIndex

### DIFF
--- a/ARKBreedingStats/Form1.cs
+++ b/ARKBreedingStats/Form1.cs
@@ -1777,6 +1777,12 @@ namespace ARKBreedingStats
                 creatureCollection.multipliers = oldMultipliers ?? Values.V.getOfficialMultipliers();
             }
 
+            if (speciesSelector1.LastSpecies != null && speciesSelector1.LastSpecies.Length > 0)
+            {
+                var lastSpecies = speciesSelector1.LastSpecies[0];
+                tamingControl1.setSpeciesIndex(Values.V.speciesIndex(lastSpecies));
+            }
+
             applySettingsToValues();
 
             bool creatureWasAdded = false;


### PR DESCRIPTION
Removes exception when a species' index was changed after adding/removing a creature to the list and ASB couldn't find a matching food.