### PR TITLE
sync species selection to breeding plan & save ignore cooldown checkbox

### DIFF
--- a/ARKBreedingStats/App.config
+++ b/ARKBreedingStats/App.config
@@ -154,6 +154,9 @@
             <setting name="UseOwnerFilterForBreedingPlan" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="IgnoreCooldown" serializeAs="String">
+                <value>False</value>
+            </setting>
         </ARKBreedingStats.Properties.Settings>
     </userSettings>
 </configuration>

--- a/ARKBreedingStats/BreedingPlan.cs
+++ b/ARKBreedingStats/BreedingPlan.cs
@@ -70,6 +70,7 @@ namespace ARKBreedingStats
 
             cbServerFilterLibrary.Checked = Properties.Settings.Default.UseServerFilterForBreedingPlan;
             cbOwnerFilterLibrary.Checked = Properties.Settings.Default.UseOwnerFilterForBreedingPlan;
+            cnBPIncludeCooldowneds.Checked = Properties.Settings.Default.IgnoreCooldown;
 
             tagSelectorList1.OnTagChanged += TagSelectorList1_OnTagChanged;
         }
@@ -842,6 +843,7 @@ namespace ARKBreedingStats
 
         private void checkBoxIncludeCooldowneds_CheckedChanged(object sender, EventArgs e)
         {
+            Properties.Settings.Default.IgnoreCooldown = cnBPIncludeCooldowneds.Checked;
             determineBestBreeding(chosenCreature, true);
         }
 

--- a/ARKBreedingStats/Form1.cs
+++ b/ARKBreedingStats/Form1.cs
@@ -2841,6 +2841,7 @@ namespace ARKBreedingStats
                     {
                         filteredList = filteredList.Where(c => c.species == selectedSpecies);
                         if (Values.V.glowSpecies.Contains(selectedSpecies)) chargeStatsHeaders = true;
+                        speciesSelector1.setSpecies(selectedSpecies);
                     }
                 }
                 for (int s = 0; s < 8; s++)

--- a/ARKBreedingStats/Properties/Settings.Designer.cs
+++ b/ARKBreedingStats/Properties/Settings.Designer.cs
@@ -675,5 +675,17 @@ namespace ARKBreedingStats.Properties {
                 this["UseOwnerFilterForBreedingPlan"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool IgnoreCooldown {
+            get {
+                return ((bool)(this["IgnoreCooldown"]));
+            }
+            set {
+                this["IgnoreCooldown"] = value;
+            }
+        }
     }
 }

--- a/ARKBreedingStats/Properties/Settings.settings
+++ b/ARKBreedingStats/Properties/Settings.settings
@@ -167,5 +167,8 @@
     <Setting Name="UseOwnerFilterForBreedingPlan" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="IgnoreCooldown" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
I removed the setting in the settings form and just used the checkbox in the breeding plan. It will now save to user settings like the stat weights.