### PR TITLE
Improvement for #924 (#925)

### DIFF
--- a/ARKBreedingStats/BreedingPlan.cs
+++ b/ARKBreedingStats/BreedingPlan.cs
@@ -298,6 +298,9 @@ namespace ARKBreedingStats
                         int nrTS = 0;
                         double eTS = 0;
 
+                        int topfemale = 0;
+                        int topmale = 0;
+
                         for (int s = 0; s < statsCount; s++)
                         {
                             if (s == (int)StatNames.Torpidity) continue;
@@ -328,6 +331,10 @@ namespace ARKBreedingStats
                                     {
                                         nrTS++;
                                         eTS += female.levelsWild[s] == topStats[s] && male.levelsWild[s] == topStats[s] ? 1 : probHigherLvl;
+                                        if (female.levelsWild[s] == topStats[s])
+                                            topfemale++;
+                                        if (male.levelsWild[s] == topStats[s])
+                                            topmale++;
                                     }
                                 }
                             }
@@ -336,7 +343,7 @@ namespace ARKBreedingStats
 
                         if (breedingMode == BreedingMode.TopStatsConservative)
                         {
-                            if (female.topStatsCountBP < nrTS && male.topStatsCountBP < nrTS)
+                            if (topfemale < nrTS && topmale < nrTS)
                                 t += eTS;
                             else
                                 t += .1 * eTS;


### PR DESCRIPTION
* Breeding in conservative mode with at least one stat set to 0.0 weight compared the count of top stats on the breeding suggestions not including the ones set to 0 with the top stats of the dinos including the 0 weight ones. To improve the breeding score now those stats that are set to 0.0 weight are considered top stats on the suggested dino always.

* Refinement of the change to the score - instead of counting the 0.0 weight stat as always top only count the top-stats of the male/female of those that are not 0.0 weight - else there would still be differences if they have the top-stats at the 0 weight ones or not