### PR TITLE
Modified growingUntil calc for imported saves

### DIFF
--- a/ARKBreedingStats/ImportSavegame.cs
+++ b/ARKBreedingStats/ImportSavegame.cs
@@ -196,7 +196,8 @@ namespace ARKBreedingStats
             if (creatureObject.GetPropertyValue<bool>("bIsBaby") || !string.IsNullOrWhiteSpace(imprinterName))
             {
                 double maturationTime = species.breeding?.maturationTimeAdjusted ?? 0;
-                float tamedTime = _gameTime - (float)creatureObject.GetPropertyValue<double>("TamedAtTime");
+                float babyAge = creatureObject.GetPropertyValue<float>("BabyAge");
+                float tamedTime = (float)maturationTime * (1.0f - babyAge);
                 if (tamedTime < maturationTime - 120) // there seems to be a slight offset of one of these saved values, so don't display a creature as being in cooldown if it is about to leave it in the next 2 minutes
                     creature.growingUntil = DateTime.Now.Add(TimeSpan.FromSeconds(maturationTime - tamedTime));
             }


### PR DESCRIPTION
Fixes a bug where babies that have been cryoed will never display the growing until time, unless you manually set it. This occurred because after being cryoed the TamedAtTime never gets set when the dino is deployed again. 

Also has the side effect of showing when the dino would be fully grown if taken out of a cryopod immediately.