### PR TITLE
Add species dividers to the library tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 /_publish/
+
+*.asb
+.idea/

--- a/ARKBreedingStats/Form1.cs
+++ b/ARKBreedingStats/Form1.cs
@@ -172,6 +172,10 @@ namespace ARKBreedingStats
             listViewLibrary.VirtualMode = true;
             listViewLibrary.RetrieveVirtualItem += ListViewLibrary_RetrieveVirtualItem;
             listViewLibrary.CacheVirtualItems += ListViewLibrary_CacheVirtualItems;
+            listViewLibrary.OwnerDraw = true;
+            listViewLibrary.DrawItem += ListViewLibrary_DrawItem;
+            listViewLibrary.DrawColumnHeader += (sender, args) => args.DrawDefault = true;
+            listViewLibrary.DrawSubItem += ListViewLibrary_DrawSubItem;
 
             speciesSelector1.SetTextBox(tbSpeciesGlobal);
 

--- a/ARKBreedingStats/Form1.library.cs
+++ b/ARKBreedingStats/Form1.library.cs
@@ -1276,6 +1276,14 @@ namespace ARKBreedingStats
         /// </summary>
         private void LibrarySelectedIndexChanged()
         {
+            for (var index = 0; index < listViewLibrary.SelectedIndices.Count; index++)
+            {
+                var creatureIdx = listViewLibrary.SelectedIndices[index];
+                Creature c = _creaturesDisplayed[creatureIdx];
+                if (!c.flags.HasFlag(CreatureFlags.Divider)) continue;
+                listViewLibrary.SelectedIndices.Remove(creatureIdx);
+            }
+
             int cnt = listViewLibrary.SelectedIndices.Count;
             if (cnt == 0)
             {

--- a/ARKBreedingStats/library/Creature.cs
+++ b/ARKBreedingStats/library/Creature.cs
@@ -570,9 +570,10 @@ namespace ARKBreedingStats.Library
         Female = 512,
         Male = 1024,
         MutagenApplied = 2048,
+        Divider = 4096,
         /// <summary>
         /// If applied to the flags with &, the status is removed.
         /// </summary>
-        StatusMask = Mutated | Neutered | Placeholder | Female | Male | MutagenApplied
+        StatusMask = Mutated | Neutered | Placeholder | Female | Male | MutagenApplied | Divider
     }
 }

--- a/ARKBreedingStats/utils/CreatureListSorter.cs
+++ b/ARKBreedingStats/utils/CreatureListSorter.cs
@@ -34,7 +34,7 @@ namespace ARKBreedingStats.utils
         /// <summary>
         /// Sort list by given column index. If the columnIndex is -1, use last sorting.
         /// </summary>
-        public Creature[] DoSort(IEnumerable<Creature> list, int columnIndex = -1, Species[] orderBySpecies = null)
+        public IEnumerable<Creature> DoSort(IEnumerable<Creature> list, int columnIndex = -1, Species[] orderBySpecies = null)
         {
             if (list == null) return null;
 
@@ -54,7 +54,7 @@ namespace ARKBreedingStats.utils
             }
 
             // Perform the sort with these new sort options.
-            return OrderList(list, orderBySpecies).ToArray();
+            return OrderList(list, orderBySpecies);
         }
 
         private IEnumerable<Creature> OrderList(IEnumerable<Creature> list, Species[] orderBySpecies = null)


### PR DESCRIPTION
This PR adds dividers for species to the library tab.
I haven't implemented double-clicking dividers to select the whole species group, as it was not a use case I had, and shift-selecting large groups of dinos is quick enough.
![image](https://user-images.githubusercontent.com/29176781/205887881-dbfafce4-c030-444e-b576-15d501be36f6.png)
