### PR TITLE
Add natural sorting for the library view

### DIFF
--- a/ARKBreedingStats/ARKBreedingStats.csproj
+++ b/ARKBreedingStats/ARKBreedingStats.csproj
@@ -636,6 +636,7 @@
     <Compile Include="utils\CreatureListSorter.cs" />
     <Compile Include="utils\MessageBoxes.cs" />
     <Compile Include="NamePatterns\NamePatternFunctions.cs" />
+    <Compile Include="utils\NaturalComparer.cs" />
     <Compile Include="utils\RepositoryInfo.cs" />
     <Compile Include="utils\SoundFeedback.cs" />
     <Compile Include="utils\Themes.cs" />

--- a/ARKBreedingStats/utils/CreatureListSorter.cs
+++ b/ARKBreedingStats/utils/CreatureListSorter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using ARKBreedingStats.Library;
@@ -8,7 +7,6 @@ using ARKBreedingStats.species;
 
 namespace ARKBreedingStats.utils
 {
-
     public class CreatureListSorter
     {
         /// <summary>
@@ -32,6 +30,16 @@ namespace ARKBreedingStats.utils
         private SortOrder _lastOrder;
 
         /// <summary>
+        /// Whether to use natural sort. If false, normal lexicographical sort is used.
+        /// </summary>
+        public bool UseNaturalSort { get; set; } = false;
+
+        /// <summary>
+        /// Whether to ignore spaces between words. This option is only relevant whern using natural sort.
+        /// </summary>
+        public bool IgnoreSpacesBetweenWords { get; set; } = false;
+
+        /// <summary>
         /// Sort list by given column index. If the columnIndex is -1, use last sorting.
         /// </summary>
         public IEnumerable<Creature> DoSort(IEnumerable<Creature> list, int columnIndex = -1, Species[] orderBySpecies = null)
@@ -53,13 +61,19 @@ namespace ARKBreedingStats.utils
                 Order = columnIndex > 1 ? SortOrder.Descending : SortOrder.Ascending;
             }
 
+            // Select a comparison function
+            IComparer<object> comparer = UseNaturalSort
+                ? new NaturalComparer(skipSpaces: IgnoreSpacesBetweenWords)
+                : (IComparer<object>)Comparer<object>.Default;
+
             // Perform the sort with these new sort options.
-            return OrderList(list, orderBySpecies);
+            return OrderList(list, comparer, orderBySpecies);
         }
 
-        private IEnumerable<Creature> OrderList(IEnumerable<Creature> list, Species[] orderBySpecies = null)
+        private IEnumerable<Creature> OrderList(IEnumerable<Creature> list, IComparer<object> comparer, Species[] orderBySpecies = null)
         {
             IOrderedEnumerable<Creature> listOrdered;
+
             if (orderBySpecies != null)
             {
                 var dict = orderBySpecies.Select((s, i) => (s, i)).ToDictionary(s => s.s, s => s.i);
@@ -67,16 +81,16 @@ namespace ARKBreedingStats.utils
                 if (SortColumnIndex == -1 || SortColumnIndex >= _keySelectors.Length)
                     return listOrdered;
                 listOrdered = Order == SortOrder.Ascending
-                    ? listOrdered.ThenBy(_keySelectors[SortColumnIndex])
-                    : listOrdered.ThenByDescending(_keySelectors[SortColumnIndex]);
+                    ? listOrdered.ThenBy(_keySelectors[SortColumnIndex], comparer)
+                    : listOrdered.ThenByDescending(_keySelectors[SortColumnIndex], comparer);
             }
             else
             {
                 if (SortColumnIndex == -1 || SortColumnIndex >= _keySelectors.Length)
                     return list;
                 listOrdered = Order == SortOrder.Ascending
-                    ? list.OrderBy(_keySelectors[SortColumnIndex])
-                    : list.OrderByDescending(_keySelectors[SortColumnIndex]);
+                    ? list.OrderBy(_keySelectors[SortColumnIndex], comparer)
+                    : list.OrderByDescending(_keySelectors[SortColumnIndex], comparer);
             }
 
             if (_lastSortColumnIndex == -1 || _lastSortColumnIndex >= _keySelectors.Length)
@@ -84,8 +98,8 @@ namespace ARKBreedingStats.utils
 
             // sort by second column that was selected previously
             return _lastOrder == SortOrder.Ascending
-                ? listOrdered.ThenBy(_keySelectors[_lastSortColumnIndex])
-                : listOrdered.ThenByDescending(_keySelectors[_lastSortColumnIndex]);
+                ? listOrdered.ThenBy(_keySelectors[_lastSortColumnIndex], comparer)
+                : listOrdered.ThenByDescending(_keySelectors[_lastSortColumnIndex], comparer);
         }
 
         /// <summary>

--- a/ARKBreedingStats/utils/NaturalComparer.cs
+++ b/ARKBreedingStats/utils/NaturalComparer.cs
@@ -1,0 +1,144 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace ARKBreedingStats.utils
+{
+    class NaturalStringComparer : IComparer<string>
+    {
+        public bool SkipSpaces { get; set; } = false;
+
+        int IComparer<string>.Compare(string aStr, string bStr)
+        {
+            if (aStr is null && bStr is null) return 0;
+            if (aStr is null) return -1;
+            if (bStr is null) return 1;
+
+            // State vars
+            int aI = 0;
+            int bI = 0;
+            int aLen = aStr.Length;
+            int bLen = bStr.Length;
+
+            while (true)
+            {
+                // Handle when we hit the end of either string
+                if (aI >= aLen && bI >= bLen) return 0;
+                if (aI >= aLen) return -1; // The shorter string sorts first
+                if (bI >= bLen) return 1;
+
+                // Skip spaces on both sides, if requested
+                if (SkipSpaces)
+                {
+                    aI += SkipWhiteSpace(aStr, aI);
+                    bI += SkipWhiteSpace(bStr, bI);
+                }
+
+                // Pick up the next character from each string
+                char a = aStr[aI];
+                char b = bStr[bI];
+
+                // Easy case - one or both sides are not digits
+                if (!IsDigit(a) || !IsDigit(b))
+                {
+                    // Use simple ASCII indexes to compare characters
+                    // (may want to upgrade to Unicode comparisons)
+                    if (a > b) return 1;
+                    if (b > a) return -1;
+
+                    // Both match, so move on
+                    aI += 1;
+                    bI += 1;
+                    continue;
+                }
+
+                // Both sides are numbers so compare runs of digits as numbers
+                var (aNum, aSpanLen) = ParseNumber(aStr, aI);
+                var (bNum, bSpanLen) = ParseNumber(bStr, bI);
+                if (aNum > bNum) return 1;
+                if (bNum > aNum) return -1;
+                aI += aSpanLen;
+                bI += bSpanLen;
+            }
+        }
+
+        bool IsDigit(char c)
+        {
+            return c >= '0' && c <= '9';
+        }
+
+        /// <summary>
+        /// Take characters from a string at the given start position, parsing them into an integer.
+        /// Stops when any non-digit is found.
+        /// </summary>
+        /// <returns>The value of the integer and the number of characters consumed.</returns>
+        (int value, int len) ParseNumber(string str, int start)
+        {
+            int acc = 0;
+            int len = 0;
+
+            for (int i = start; i < str.Length; i++)
+            {
+                char c = str[i];
+                if (!IsDigit(c)) break;
+
+                acc = acc * 10 + (c - '0');
+                len += 1;
+            }
+
+            return (acc, len);
+        }
+
+        /// <summary>
+        /// Consume whitespace from the string.
+        /// </summary>
+        /// <returns>The number of characters consumed.</returns>
+        int SkipWhiteSpace(string str, int start)
+        {
+            int len = 0;
+            for (int i = start; i < str.Length; i++)
+            {
+                char c = str[i];
+                if (!char.IsWhiteSpace(c)) break;
+                len += 1;
+            }
+
+            return len;
+        }
+    }
+
+
+    /// <summary>
+    /// A comparer that uses natural sorting for strings and delegates to the
+    /// system comparer for any other types.
+    /// </summary>
+    class NaturalComparer : IComparer, IComparer<object>
+    {
+        readonly IComparer<string> _stringComparer;
+
+        int IComparer<object>.Compare(object a, object b) => InternalCompare(a, b);
+        int IComparer.Compare(object a, object b) => InternalCompare(a, b);
+
+        /// <summary>
+        /// A natural sort comparer.
+        /// </summary>
+        /// <param name="skipSpaces">If true, white space between words is ignored.</param>
+        public NaturalComparer(bool skipSpaces = false)
+        {
+            _stringComparer = new NaturalStringComparer() { SkipSpaces = skipSpaces };
+        }
+
+        int InternalCompare(object a, object b)
+        {
+            // Handle cases with nulls and where both references point to the same object
+            if (ReferenceEquals(a, b)) return 0; // includes if both are null
+            if (a is null) return -1;
+            if (b is null) return 1;
+
+            // Use our natural comparer if both are strings
+            if (a is string aStr && b is string bStr) return _stringComparer.Compare(aStr, bStr);
+
+            // Fall back to the correct comparer for this type
+            return Comparer.Default.Compare(a, b);
+        }
+    }
+}


### PR DESCRIPTION
Natural sorting means that "10" would be sorted after "2", which is not currently the case with regular lexicographical sorting. It will be applied to any sorted column if the column contains strings.

This feature has to be enabled via a setting and could perhaps become the default in future if the tested performance impact is not bad.

This initial commit implements the algorithm but still needs to be hooked up via settings to enable it.