### PR TITLE
Updated ATLAS Values File

### DIFF
--- a/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
+++ b/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
@@ -27,7 +27,14 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
+			"breeding": {
+				"gestationTime": 14400.1958,
+				"incubationTime": 0,
+				"maturationTime": 151199.6939,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main",
@@ -261,6 +268,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 12600.4095,
+				"incubationTime": 0,
+				"maturationTime": 147599.7331,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main",
@@ -413,6 +427,15 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 0,
+				"incubationTime": 7199.42405,
+				"eggTempMin": 20,
+				"eggTempMax": 28,
+				"maturationTime": 166666.667,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Middle Body",
@@ -574,6 +597,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 10800.0108,
+				"incubationTime": 0,
+				"maturationTime": 142199.7736,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main",
@@ -990,6 +1020,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 16326.5306,
+				"incubationTime": 0,
+				"maturationTime": 158399.7820,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Medium Skin",
@@ -1095,6 +1132,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 24299.5650,
+				"incubationTime": 0,
+				"maturationTime": 243000.3742,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main Body",
@@ -1196,6 +1240,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 20699.7338,
+				"incubationTime": 0,
+				"maturationTime": 237599.6730,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Fur Secondary",
@@ -1307,6 +1358,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 14400.1958,
+				"incubationTime": 0,
+				"maturationTime": 158399.7820,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Body Main",
@@ -1400,6 +1458,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 17100.4480,
+				"incubationTime": 0,
+				"maturationTime": 208799.2165,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main Body",
@@ -1492,6 +1557,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 8099.6253,
+				"incubationTime": 0,
+				"maturationTime": 97200.1496,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Shoulders and Legs",
@@ -1602,6 +1674,13 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 19800.0198,
+				"incubationTime": 0,
+				"maturationTime": 219600.1958,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main",
@@ -1695,13 +1774,6 @@
 					]
 				}
 			],
-			"breeding": {
-				"gestationTime": 15037.594,
-				"incubationTime": 0,
-				"maturationTime": 175438.596,
-				"matingCooldownMin": 64800,
-				"matingCooldownMax": 172800
-			},
             "taming": {
                 "nonViolent": true,
                 "violent": false,
@@ -1738,7 +1810,7 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 0,
 				"incubationTime": 0,
 				"maturationTime": 172800,
 				"matingCooldownMin": 64800,
@@ -1894,7 +1966,7 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 0,
 				"incubationTime": 0,
 				"maturationTime": 86400,
 				"matingCooldownMin": 64800,
@@ -2063,7 +2135,7 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 0,
 				"incubationTime": 0,
 				"maturationTime": 86400,
 				"matingCooldownMin": 64800,
@@ -2200,9 +2272,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 9900.0099,
 				"incubationTime": 0,
-				"maturationTime": 115200,
+				"maturationTime": 136799.8413,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2304,9 +2376,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 6300.2047,
 				"incubationTime": 0,
-				"maturationTime": 28800,
+				"maturationTime": 29699.5886,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2381,7 +2453,7 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 0,
 				"incubationTime": 0,
 				"maturationTime": 259200,
 				"matingCooldownMin": 64800,
@@ -2535,9 +2607,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 22499.8453,
 				"incubationTime": 0,
-				"maturationTime": 230400,
+				"maturationTime": 248400.3020,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2781,9 +2853,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 14400.195,
+				"gestationTime": 14400.1958,
 				"incubationTime": 0,
-				"maturationTime": 151199.693,
+				"maturationTime": 151199.6939,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2886,9 +2958,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 14400.195,
+				"gestationTime": 9000.2925,
 				"incubationTime": 0,
-				"maturationTime": 151199.693,
+				"maturationTime": 133200.1332,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3189,9 +3261,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 18000.0180,
 				"incubationTime": 0,
-				"maturationTime": 201600,
+				"maturationTime": 214199.7283,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3370,9 +3442,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 18000.0180,
 				"incubationTime": 0,
-				"maturationTime": 201600,
+				"maturationTime": 214199.7283,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3775,9 +3847,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 12600.4095,
 				"incubationTime": 0,
-				"maturationTime": 201600,
+				"maturationTime": 188999.8317,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3927,9 +3999,9 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
+				"gestationTime": 21978.0219,
 				"incubationTime": 0,
-				"maturationTime": 201600,
+				"maturationTime": 237599.6730,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},

--- a/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
+++ b/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
@@ -429,10 +429,10 @@
             "immobilizedBy": [],
 			"breeding": {
 				"gestationTime": 0,
-				"incubationTime": 7199.42405,
-				"eggTempMin": 20,
+				"incubationTime": 17998.5601,
+				"eggTempMin": 24,
 				"eggTempMax": 28,
-				"maturationTime": 166666.667,
+				"maturationTime": 60600.3311,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -815,6 +815,15 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 0,
+				"incubationTime": 5999.5200,
+				"eggTempMin": 49,
+				"eggTempMax": 70,
+				"maturationTime": 180000.1800,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main Body Color",
@@ -899,6 +908,15 @@
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
+			"breeding": {
+				"gestationTime": 0,
+				"incubationTime": 3599.7120,
+				"eggTempMin": 35,
+				"eggTempMax": 45,
+				"maturationTime": 93600.0936,
+				"matingCooldownMin": 64800,
+				"matingCooldownMax": 172800
+			},
 			"colors": [
 				{
 					"name": "Main Body",
@@ -1811,8 +1829,10 @@
             "immobilizedBy": [],
 			"breeding": {
 				"gestationTime": 0,
-				"incubationTime": 0,
-				"maturationTime": 172800,
+				"incubationTime": 5999.5200,
+				"eggTempMin": 49,
+				"eggTempMax": 57,
+				"maturationTime": 180000.1800,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -1967,8 +1987,10 @@
             "immobilizedBy": [],
 			"breeding": {
 				"gestationTime": 0,
-				"incubationTime": 0,
-				"maturationTime": 86400,
+				"incubationTime": 2999.7600,
+				"eggTempMin": 45,
+				"eggTempMax": 55,
+				"maturationTime": 88200.2215,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2136,8 +2158,10 @@
             "immobilizedBy": [],
 			"breeding": {
 				"gestationTime": 0,
-				"incubationTime": 0,
-				"maturationTime": 86400,
+				"incubationTime": 4499.6400,
+				"eggTempMin": 8,
+				"eggTempMax": 16,
+				"maturationTime": 120600.3485,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2454,8 +2478,10 @@
             "immobilizedBy": [],
 			"breeding": {
 				"gestationTime": 0,
-				"incubationTime": 0,
-				"maturationTime": 259200,
+				"incubationTime": 11699.5320,
+				"eggTempMin": 52,
+				"eggTempMax": 58,
+				"maturationTime": 277200.2772,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -2748,9 +2774,11 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
-				"incubationTime": 0,
-				"maturationTime": 86400,
+				"gestationTime": 0,
+				"incubationTime": 3300.0660,
+				"eggTempMin": 31,
+				"eggTempMax": 41,
+				"maturationTime": 90899.5877,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3084,9 +3112,11 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 14400.195,
-				"incubationTime": 0,
-				"maturationTime": 151199.693,
+				"gestationTime": 0,
+				"incubationTime": 9900.1980,
+				"eggTempMin": 50,
+				"eggTempMax": 56,
+				"maturationTime": 268198.6171,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3261,8 +3291,10 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 18000.0180,
-				"incubationTime": 0,
+				"gestationTime": 0,
+				"incubationTime": 5999.5200,
+				"eggTempMin": 25,
+				"eggTempMax": 50,
 				"maturationTime": 214199.7283,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
@@ -3553,9 +3585,11 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
-				"incubationTime": 0,
-				"maturationTime": 201600,
+				"gestationTime": 0,
+				"incubationTime": 12599.6220,
+				"eggTempMin": 54,
+				"eggTempMax": 60,
+				"maturationTime": 279000.7309,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},
@@ -3694,9 +3728,11 @@
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
             "immobilizedBy": [],
 			"breeding": {
-				"gestationTime": 15037.594,
-				"incubationTime": 0,
-				"maturationTime": 86400,
+				"gestationTime": 0,
+				"incubationTime": 5100.1870,
+				"eggTempMin": 49,
+				"eggTempMax": 57,
+				"maturationTime": 126000.1260,
 				"matingCooldownMin": 64800,
 				"matingCooldownMax": 172800
 			},

--- a/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
+++ b/ARKBreedingStats/json/values/ATLAS/ATLAS_values.json
@@ -134,7 +134,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"colors": [
 				{
 					"name": "Body Main",
@@ -267,7 +267,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 12600.4095,
 				"incubationTime": 0,
@@ -426,7 +426,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 17998.5601,
@@ -596,7 +596,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 10800.0108,
 				"incubationTime": 0,
@@ -702,7 +702,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"colors": [
 				{
 					"name": "Body",
@@ -814,7 +814,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 5999.5200,
@@ -907,7 +907,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 3599.7120,
@@ -1037,7 +1037,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 16326.5306,
 				"incubationTime": 0,
@@ -1149,7 +1149,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 24299.5650,
 				"incubationTime": 0,
@@ -1257,7 +1257,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 20699.7338,
 				"incubationTime": 0,
@@ -1375,7 +1375,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 14400.1958,
 				"incubationTime": 0,
@@ -1475,7 +1475,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 17100.4480,
 				"incubationTime": 0,
@@ -1574,7 +1574,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 8099.6253,
 				"incubationTime": 0,
@@ -1691,7 +1691,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 19800.0198,
 				"incubationTime": 0,
@@ -1826,7 +1826,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 5999.5200,
@@ -1984,7 +1984,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 2999.7600,
@@ -2155,7 +2155,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 4499.6400,
@@ -2294,7 +2294,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 9900.0099,
 				"incubationTime": 0,
@@ -2398,7 +2398,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 6300.2047,
 				"incubationTime": 0,
@@ -2475,7 +2475,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 11699.5320,
@@ -2631,7 +2631,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 22499.8453,
 				"incubationTime": 0,
@@ -2772,7 +2772,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 3300.0660,
@@ -2879,7 +2879,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 14400.1958,
 				"incubationTime": 0,
@@ -2984,7 +2984,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 9000.2925,
 				"incubationTime": 0,
@@ -3110,7 +3110,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 9900.1980,
@@ -3289,7 +3289,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 5999.5200,
@@ -3472,7 +3472,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 18000.0180,
 				"incubationTime": 0,
@@ -3583,7 +3583,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 12599.6220,
@@ -3726,7 +3726,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 0,
 				"incubationTime": 5100.1870,
@@ -3881,7 +3881,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 12600.4095,
 				"incubationTime": 0,
@@ -4033,7 +4033,7 @@
                 null
             ],
 			"statImprintMult": [ 0.2, 0, 0.2, 0, 0.2, 0.2, 0, 0.2, 0.2, 0.2, 0, 0 ],
-            "immobilizedBy": [],
+            "immobilizedBy": ["Bola"],
 			"breeding": {
 				"gestationTime": 21978.0219,
 				"incubationTime": 0,


### PR DESCRIPTION
ATLAS breeding values updated per the Dev Kit using comparision with Purlovia for calculations.
Validated timers using Bear and Tigers as well as 3rd party sites to confirm no additional multipliers in effect.