### PR TITLE
Keep mutations when imported wild == existing mutation

### DIFF
--- a/ARKBreedingStats/Form1.extractor.cs
+++ b/ARKBreedingStats/Form1.extractor.cs
@@ -1011,7 +1011,7 @@ namespace ARKBreedingStats
                 for (int s = 0; s < Stats.StatsCount; s++)
                 {
                     var mutationLevels = alreadyExistingCreature.levelsMutated[s];
-                    if (mutationLevels > 0 && _statIOs[s].LevelWild > mutationLevels)
+                    if (mutationLevels > 0 && _statIOs[s].LevelWild >= mutationLevels)
                     {
                         _statIOs[s].LevelMut = mutationLevels;
                         _statIOs[s].LevelWild -= mutationLevels;


### PR DESCRIPTION
Import was resetting mutations when a stat has 0 wild points + mutations