### PR TITLE
Extract new mutations from parent levels

### DIFF
--- a/ARKBreedingStats/Utils.cs
+++ b/ARKBreedingStats/Utils.cs
@@ -755,14 +755,18 @@ namespace ARKBreedingStats
             }
         }
 
-        public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)
+        public static IList<IList<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)
         {
             IEnumerable<IEnumerable<T>> emptyProduct = new[] { Enumerable.Empty<T>() };
 
-            return sequences.Aggregate(emptyProduct, (accumulator, sequence) => accumulator
+            var combinations = sequences.Aggregate(emptyProduct, (accumulator, sequence) => accumulator
                 .SelectMany(accseq => sequence
                     .Select(item => accseq.Concat(new[] { item })))
             );
+
+            return combinations
+                .Select(x => x.ToArray())
+                .ToArray();
         }
     }
 }

--- a/ARKBreedingStats/Utils.cs
+++ b/ARKBreedingStats/Utils.cs
@@ -754,5 +754,15 @@ namespace ARKBreedingStats
                 return _applicationNameVersion;
             }
         }
+
+        public static IEnumerable<IEnumerable<T>> CartesianProduct<T>(this IEnumerable<IEnumerable<T>> sequences)
+        {
+            IEnumerable<IEnumerable<T>> emptyProduct = new[] { Enumerable.Empty<T>() };
+
+            return sequences.Aggregate(emptyProduct, (accumulator, sequence) => accumulator
+                .SelectMany(accseq => sequence
+                    .Select(item => accseq.Concat(new[] { item })))
+            );
+        }
     }
 }


### PR DESCRIPTION
This solves for mutation counts given:
- We have wild level extract for the import
- and we have both parents
- and both parents have trustable mutation data
  - mutation levels are > 0
  - or mutation levels == 0 and we trust the mutation count
    - we have > 0 mutations
    - or we have 0 mutations on a tame
    - or we have parent info (assume importing parent info means we also imported accurate mutation count)
 
 if we have mutation count on the import, we can use it to resolve ambiguities