### PR TITLE
Allow tab key indentation in the pattern editor

### DIFF
--- a/ARKBreedingStats/NamePatterns/PatternEditor.Designer.cs
+++ b/ARKBreedingStats/NamePatterns/PatternEditor.Designer.cs
@@ -67,6 +67,7 @@
             // 
             // txtboxPattern
             // 
+            this.txtboxPattern.AcceptsTab = true;
             this.txtboxPattern.Dock = System.Windows.Forms.DockStyle.Fill;
             this.txtboxPattern.Font = new System.Drawing.Font("Consolas", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtboxPattern.Location = new System.Drawing.Point(0, 0);


### PR DESCRIPTION
If nothing is selected:
- Tab should insert 2 spaces at the cursor.
- Shift+tab should remove a tab or up to 2 spaces from before the cursor.

With text selected:
- Tab should add 2 spaces to the beginning of the selected lines
- Shift+tab should remove a tab or up to 2 spaces from the beginning
- Having the cursor at the start of a line doesn't include that line in the selection
