### PR TITLE
switched parent mutation order

### DIFF
--- a/ARKBreedingStats/CreatureInfoInput.Designer.cs
+++ b/ARKBreedingStats/CreatureInfoInput.Designer.cs
@@ -31,6 +31,7 @@ namespace ARKBreedingStats
         private void InitializeComponent()
         {
             this.gbCreatureInfo = new System.Windows.Forms.GroupBox();
+            this.BtTraits = new System.Windows.Forms.Button();
             this.CbMutagen = new System.Windows.Forms.CheckBox();
             this.LbColorNewInRegion = new System.Windows.Forms.Label();
             this.LbColorNewInSpecies = new System.Windows.Forms.Label();
@@ -84,7 +85,6 @@ namespace ARKBreedingStats
             this.lbOwner = new System.Windows.Forms.Label();
             this.lbName = new System.Windows.Forms.Label();
             this.btAdd2Library = new System.Windows.Forms.Button();
-            this.BtTraits = new System.Windows.Forms.Button();
             this.gbCreatureInfo.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMutationsFather)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMutationsMother)).BeginInit();
@@ -155,6 +155,16 @@ namespace ARKBreedingStats
             this.gbCreatureInfo.TabStop = false;
             this.gbCreatureInfo.Text = "Creature-info";
             this.gbCreatureInfo.Enter += new System.EventHandler(this.groupBox1_Enter);
+            // 
+            // BtTraits
+            // 
+            this.BtTraits.Location = new System.Drawing.Point(9, 412);
+            this.BtTraits.Name = "BtTraits";
+            this.BtTraits.Size = new System.Drawing.Size(53, 23);
+            this.BtTraits.TabIndex = 54;
+            this.BtTraits.Text = "Traits";
+            this.BtTraits.UseVisualStyleBackColor = true;
+            this.BtTraits.Click += new System.EventHandler(this.BtTraits_Click);
             // 
             // CbMutagen
             // 
@@ -364,7 +374,7 @@ namespace ARKBreedingStats
             // nudMutationsFather
             // 
             this.nudMutationsFather.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.nudMutationsFather.Location = new System.Drawing.Point(196, 386);
+            this.nudMutationsFather.Location = new System.Drawing.Point(107, 386);
             this.nudMutationsFather.Maximum = new decimal(new int[] {
             2147483647,
             0,
@@ -382,13 +392,13 @@ namespace ARKBreedingStats
             0,
             0});
             this.nudMutationsFather.Size = new System.Drawing.Size(60, 20);
-            this.nudMutationsFather.TabIndex = 13;
+            this.nudMutationsFather.TabIndex = 12;
             this.nudMutationsFather.ValueChanged += new System.EventHandler(this.NudMutations_ValueChanged);
             // 
             // nudMutationsMother
             // 
             this.nudMutationsMother.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.nudMutationsMother.Location = new System.Drawing.Point(107, 386);
+            this.nudMutationsMother.Location = new System.Drawing.Point(196, 386);
             this.nudMutationsMother.Maximum = new decimal(new int[] {
             2147483647,
             0,
@@ -406,25 +416,25 @@ namespace ARKBreedingStats
             0,
             0});
             this.nudMutationsMother.Size = new System.Drawing.Size(60, 20);
-            this.nudMutationsMother.TabIndex = 12;
+            this.nudMutationsMother.TabIndex = 13;
             this.nudMutationsMother.ValueChanged += new System.EventHandler(this.NudMutations_ValueChanged);
             // 
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(173, 388);
+            this.label12.Location = new System.Drawing.Point(85, 388);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(19, 13);
-            this.label12.TabIndex = 34;
+            this.label12.TabIndex = 33;
             this.label12.Text = "♂";
             // 
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(85, 388);
+            this.label11.Location = new System.Drawing.Point(173, 388);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(19, 13);
-            this.label11.TabIndex = 33;
+            this.label11.TabIndex = 34;
             this.label11.Text = "♀";
             // 
             // dhmsInputGrown
@@ -714,16 +724,6 @@ namespace ARKBreedingStats
             this.btAdd2Library.Text = "Add new to Library";
             this.btAdd2Library.UseVisualStyleBackColor = true;
             this.btAdd2Library.Click += new System.EventHandler(this.buttonAdd2Library_Click);
-            // 
-            // BtTraits
-            // 
-            this.BtTraits.Location = new System.Drawing.Point(9, 412);
-            this.BtTraits.Name = "BtTraits";
-            this.BtTraits.Size = new System.Drawing.Size(53, 23);
-            this.BtTraits.TabIndex = 54;
-            this.BtTraits.Text = "Traits";
-            this.BtTraits.UseVisualStyleBackColor = true;
-            this.BtTraits.Click += new System.EventHandler(this.BtTraits_Click);
             // 
             // CreatureInfoInput
             // 


### PR DESCRIPTION
switched the order of parent mutations in CreatureInfoInput.cs (now male/father first) to match the binoculars ingame. Based on suggestion: https://discord.com/channels/372139935815434240/372143053185613825/1469488722301943890

<img width="263" height="30" alt="image" src="https://github.com/user-attachments/assets/d87005e2-8045-4746-8bb2-a1129ed17e5d" />

Ingame:
<img width="352" height="537" alt="image" src="https://github.com/user-attachments/assets/e4b38859-7541-4706-af48-00697b1dfba8" />

(The ancestry tab ingame is showing it the other way around but that's an inconsistency in the game and I would argue it is more useful to follow UI of the binoculars and Export Gun.)
