### PR TITLE
Add support for archetype base parent matching

### DIFF
--- a/ARKBreedingStats/CreatureInfoInput.Designer.cs
+++ b/ARKBreedingStats/CreatureInfoInput.Designer.cs
@@ -42,7 +42,7 @@ namespace ARKBreedingStats
             btNamingPattern4 = new System.Windows.Forms.Button();
             btNamingPattern3 = new System.Windows.Forms.Button();
             btNamingPattern2 = new System.Windows.Forms.Button();
-            btNamingPatternEditor = new System.Windows.Forms.Button();
+            cbArchetype = new System.Windows.Forms.CheckBox();
             btnGenerateUniqueName = new System.Windows.Forms.Button();
             TbArkIdIngame = new System.Windows.Forms.TextBox();
             TbArkId = new System.Windows.Forms.TextBox();
@@ -104,7 +104,7 @@ namespace ARKBreedingStats
             gbCreatureInfo.Controls.Add(btNamingPattern4);
             gbCreatureInfo.Controls.Add(btNamingPattern3);
             gbCreatureInfo.Controls.Add(btNamingPattern2);
-            gbCreatureInfo.Controls.Add(btNamingPatternEditor);
+            gbCreatureInfo.Controls.Add(cbArchetype);
             gbCreatureInfo.Controls.Add(btnGenerateUniqueName);
             gbCreatureInfo.Controls.Add(TbArkIdIngame);
             gbCreatureInfo.Controls.Add(TbArkId);
@@ -228,10 +228,10 @@ namespace ARKBreedingStats
             // 
             // btNamingPattern6
             // 
-            btNamingPattern6.Location = new System.Drawing.Point(257, 51);
-            btNamingPattern6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btNamingPattern6.Location = new System.Drawing.Point(262, 51);
+            btNamingPattern6.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btNamingPattern6.Name = "btNamingPattern6";
-            btNamingPattern6.Size = new System.Drawing.Size(42, 23);
+            btNamingPattern6.Size = new System.Drawing.Size(36, 23);
             btNamingPattern6.TabIndex = 48;
             btNamingPattern6.TabStop = false;
             btNamingPattern6.Text = "G6";
@@ -239,10 +239,10 @@ namespace ARKBreedingStats
             // 
             // btNamingPattern5
             // 
-            btNamingPattern5.Location = new System.Drawing.Point(208, 51);
-            btNamingPattern5.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btNamingPattern5.Location = new System.Drawing.Point(222, 51);
+            btNamingPattern5.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btNamingPattern5.Name = "btNamingPattern5";
-            btNamingPattern5.Size = new System.Drawing.Size(42, 23);
+            btNamingPattern5.Size = new System.Drawing.Size(36, 23);
             btNamingPattern5.TabIndex = 47;
             btNamingPattern5.TabStop = false;
             btNamingPattern5.Text = "G5";
@@ -250,10 +250,10 @@ namespace ARKBreedingStats
             // 
             // btNamingPattern4
             // 
-            btNamingPattern4.Location = new System.Drawing.Point(159, 51);
-            btNamingPattern4.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btNamingPattern4.Location = new System.Drawing.Point(182, 51);
+            btNamingPattern4.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btNamingPattern4.Name = "btNamingPattern4";
-            btNamingPattern4.Size = new System.Drawing.Size(42, 23);
+            btNamingPattern4.Size = new System.Drawing.Size(36, 23);
             btNamingPattern4.TabIndex = 46;
             btNamingPattern4.TabStop = false;
             btNamingPattern4.Text = "G4";
@@ -261,10 +261,10 @@ namespace ARKBreedingStats
             // 
             // btNamingPattern3
             // 
-            btNamingPattern3.Location = new System.Drawing.Point(110, 51);
-            btNamingPattern3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btNamingPattern3.Location = new System.Drawing.Point(141, 51);
+            btNamingPattern3.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btNamingPattern3.Name = "btNamingPattern3";
-            btNamingPattern3.Size = new System.Drawing.Size(42, 23);
+            btNamingPattern3.Size = new System.Drawing.Size(36, 23);
             btNamingPattern3.TabIndex = 45;
             btNamingPattern3.TabStop = false;
             btNamingPattern3.Text = "G3";
@@ -272,32 +272,34 @@ namespace ARKBreedingStats
             // 
             // btNamingPattern2
             // 
-            btNamingPattern2.Location = new System.Drawing.Point(61, 51);
-            btNamingPattern2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btNamingPattern2.Location = new System.Drawing.Point(100, 51);
+            btNamingPattern2.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btNamingPattern2.Name = "btNamingPattern2";
-            btNamingPattern2.Size = new System.Drawing.Size(42, 23);
+            btNamingPattern2.Size = new System.Drawing.Size(36, 23);
             btNamingPattern2.TabIndex = 44;
             btNamingPattern2.TabStop = false;
             btNamingPattern2.Text = "G2";
             btNamingPattern2.UseVisualStyleBackColor = true;
             // 
-            // btNamingPatternEditor
+            // cbArchetype
             // 
-            btNamingPatternEditor.Location = new System.Drawing.Point(271, 22);
-            btNamingPatternEditor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            btNamingPatternEditor.Name = "btNamingPatternEditor";
-            btNamingPatternEditor.Size = new System.Drawing.Size(28, 23);
-            btNamingPatternEditor.TabIndex = 43;
-            btNamingPatternEditor.Text = "⚙";
-            btNamingPatternEditor.UseVisualStyleBackColor = true;
-            btNamingPatternEditor.Click += btNamingPatternEditor_Click;
+            cbArchetype.Appearance = System.Windows.Forms.Appearance.Button;
+            cbArchetype.Location = new System.Drawing.Point(222, 20);
+            cbArchetype.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cbArchetype.Padding = new System.Windows.Forms.Padding(0, 0, 0, 0);
+            cbArchetype.Name = "cbArchetype";
+            cbArchetype.Size = new System.Drawing.Size(76, 25);
+            cbArchetype.TabIndex = 55;
+            cbArchetype.Text = "Archetype";
+            cbArchetype.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            cbArchetype.UseVisualStyleBackColor = true;
             // 
             // btnGenerateUniqueName
             // 
-            btnGenerateUniqueName.Location = new System.Drawing.Point(236, 22);
-            btnGenerateUniqueName.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnGenerateUniqueName.Location = new System.Drawing.Point(58, 51);
+            btnGenerateUniqueName.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             btnGenerateUniqueName.Name = "btnGenerateUniqueName";
-            btnGenerateUniqueName.Size = new System.Drawing.Size(30, 23);
+            btnGenerateUniqueName.Size = new System.Drawing.Size(36, 23);
             btnGenerateUniqueName.TabIndex = 1;
             btnGenerateUniqueName.TabStop = false;
             btnGenerateUniqueName.Text = "G1";
@@ -389,7 +391,7 @@ namespace ARKBreedingStats
             textBoxName.Location = new System.Drawing.Point(58, 22);
             textBoxName.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBoxName.Name = "textBoxName";
-            textBoxName.Size = new System.Drawing.Size(170, 23);
+            textBoxName.Size = new System.Drawing.Size(159, 23);
             textBoxName.TabIndex = 0;
             textBoxName.TextChanged += textBoxName_TextChanged;
             // 
@@ -795,7 +797,7 @@ namespace ARKBreedingStats
         private System.Windows.Forms.Label LbArkIdIngame;
         private System.Windows.Forms.TextBox TbArkIdIngame;
         private System.Windows.Forms.Label lbNewMutations;
-        private System.Windows.Forms.Button btNamingPatternEditor;
+        private System.Windows.Forms.CheckBox cbArchetype;
         private System.Windows.Forms.Button btNamingPattern6;
         private System.Windows.Forms.Button btNamingPattern5;
         private System.Windows.Forms.Button btNamingPattern4;

--- a/ARKBreedingStats/CreatureInfoInput.cs
+++ b/ARKBreedingStats/CreatureInfoInput.cs
@@ -352,6 +352,7 @@ namespace ARKBreedingStats
                 btSaveChanges.Visible = value;
                 btAdd2Library.Size = new Size((value ? Width / 2 : Width) - 10, btAdd2Library.Size.Height);
                 btAdd2Library.Location = new Point(value ? Width / 2 + 6 : 6, btAdd2Library.Location.Y);
+                btAdd2Library.Update();
             }
         }
 
@@ -511,6 +512,9 @@ namespace ARKBreedingStats
                 if (CbMutagen.Checked)
                     _creatureFlags |= CreatureFlags.MutagenApplied;
                 else _creatureFlags &= ~CreatureFlags.MutagenApplied;
+                if (cbArchetype.Checked)
+                    _creatureFlags |= CreatureFlags.Archetype;
+                else _creatureFlags &= ~CreatureFlags.Archetype;
                 if (MutationCounterMother > 0 || MutationCounterFather > 0)
                     _creatureFlags |= CreatureFlags.Mutated;
                 else _creatureFlags &= ~CreatureFlags.Mutated;
@@ -522,6 +526,7 @@ namespace ARKBreedingStats
                 _creatureFlags = value;
                 cbNeutered.Checked = _creatureFlags.HasFlag(CreatureFlags.Neutered);
                 CbMutagen.Checked = _creatureFlags.HasFlag(CreatureFlags.MutagenApplied);
+                cbArchetype.Checked = _creatureFlags.HasFlag(CreatureFlags.Archetype);
             }
         }
 
@@ -954,6 +959,7 @@ namespace ARKBreedingStats
         {
             Loc.ControlText(gbCreatureInfo);
             Loc.ControlText(lbName, "Name", _tt);
+            Loc.ControlText(cbArchetype, _tt);
             Loc.ControlText(lbOwner, "Owner", _tt);
             Loc.ControlText(lbTribe, "Tribe", _tt);
             Loc.ControlText(lbServer, "Server", _tt);

--- a/ARKBreedingStats/Form1.extractor.cs
+++ b/ARKBreedingStats/Form1.extractor.cs
@@ -1377,6 +1377,21 @@ namespace ARKBreedingStats
                 {
                     cv.Mother = mother;
                 }
+                else if (!string.IsNullOrEmpty(cv.motherName))
+                {
+                    var archetype = _creatureCollection.creatures.FirstOrDefault(a =>
+                        a.flags.HasFlag(CreatureFlags.Archetype)
+                        && a.Species == cv.Species
+                        && a.name == cv.motherName
+                        && (a.sex == Sex.Female || a.sex == Sex.Unknown));
+                    if (archetype != null)
+                        cv.Mother = archetype;
+                    else if (cv.motherArkId != 0)
+                    {
+                        cv.Mother = new Creature(cv.motherArkId, cv.Species);
+                        _creatureCollection.creatures.Add(cv.Mother);
+                    }
+                }
                 else if (cv.motherArkId != 0)
                 {
                     cv.Mother = new Creature(cv.motherArkId, cv.Species);
@@ -1389,6 +1404,21 @@ namespace ARKBreedingStats
                 if (_creatureCollection.CreatureById(useGuid, cv.fatherArkId, out Creature father))
                 {
                     cv.Father = father;
+                }
+                else if (!string.IsNullOrEmpty(cv.fatherName))
+                {
+                    var archetype = _creatureCollection.creatures.FirstOrDefault(a =>
+                        a.flags.HasFlag(CreatureFlags.Archetype)
+                        && a.Species == cv.Species
+                        && a.name == cv.fatherName
+                        && (a.sex == Sex.Male || a.sex == Sex.Unknown));
+                    if (archetype != null)
+                        cv.Father = archetype;
+                    else if (cv.fatherArkId != 0)
+                    {
+                        cv.Father = new Creature(cv.fatherArkId, cv.Species);
+                        _creatureCollection.creatures.Add(cv.Father);
+                    }
                 }
                 else if (cv.fatherArkId != 0)
                 {
@@ -1440,9 +1470,24 @@ namespace ARKBreedingStats
                 }
                 else
                 {
-                    c.Mother = new Creature(c.motherGuid, c.Species, c.Species.NoGender ? Sex.Unknown : Sex.Female);
-                    c.Mother.name = (c.Mother.sex == Sex.Female ? "Mother" : "Parent") + " of " + c.name;
-                    _creatureCollection.creatures.Add(c.Mother);
+                    // Check for an archetype creature matching by name, species, and sex
+                    var archetype = !string.IsNullOrEmpty(c.motherName)
+                        ? _creatureCollection.creatures.FirstOrDefault(a =>
+                            a.flags.HasFlag(CreatureFlags.Archetype)
+                            && a.Species == c.Species
+                            && a.name == c.motherName
+                            && (a.sex == Sex.Female || a.sex == Sex.Unknown))
+                        : null;
+                    if (archetype != null)
+                    {
+                        c.Mother = archetype;
+                    }
+                    else
+                    {
+                        c.Mother = new Creature(c.motherGuid, c.Species, c.Species.NoGender ? Sex.Unknown : Sex.Female);
+                        c.Mother.name = (c.Mother.sex == Sex.Female ? "Mother" : "Parent") + " of " + c.name;
+                        _creatureCollection.creatures.Add(c.Mother);
+                    }
                 }
             }
             if (c.Father == null && c.fatherGuid != Guid.Empty)
@@ -1453,9 +1498,24 @@ namespace ARKBreedingStats
                 }
                 else
                 {
-                    c.Father = new Creature(c.fatherGuid, c.Species, c.Species.NoGender ? Sex.Unknown : Sex.Male);
-                    c.Father.name = (c.Father.sex == Sex.Male ? "Father" : "Parent") + " of " + c.name;
-                    _creatureCollection.creatures.Add(c.Father);
+                    // Check for an archetype creature matching by name, species, and sex
+                    var archetype = !string.IsNullOrEmpty(c.fatherName)
+                        ? _creatureCollection.creatures.FirstOrDefault(a =>
+                            a.flags.HasFlag(CreatureFlags.Archetype)
+                            && a.Species == c.Species
+                            && a.name == c.fatherName
+                            && (a.sex == Sex.Male || a.sex == Sex.Unknown))
+                        : null;
+                    if (archetype != null)
+                    {
+                        c.Father = archetype;
+                    }
+                    else
+                    {
+                        c.Father = new Creature(c.fatherGuid, c.Species, c.Species.NoGender ? Sex.Unknown : Sex.Male);
+                        c.Father.name = (c.Father.sex == Sex.Male ? "Father" : "Parent") + " of " + c.name;
+                        _creatureCollection.creatures.Add(c.Father);
+                    }
                 }
             }
         }

--- a/ARKBreedingStats/Form1.library.cs
+++ b/ARKBreedingStats/Form1.library.cs
@@ -796,14 +796,36 @@ namespace ARKBreedingStats
                 if (c.motherGuid == Guid.Empty && c.fatherGuid == Guid.Empty) continue;
 
                 Creature mother = null;
-                if (c.motherGuid != Guid.Empty
-                    && !creatureGuids.TryGetValue(c.motherGuid, out mother))
-                    mother = EnsurePlaceholderCreature(placeholderAncestors, c, c.motherGuid, c.motherName, Sex.Female);
+                if (c.motherGuid != Guid.Empty && !creatureGuids.TryGetValue(c.motherGuid, out mother))
+                {
+                    // Check for an archetype creature matching by name, species, and sex
+                    if (!string.IsNullOrEmpty(c.motherName))
+                    {
+                        mother = _creatureCollection.creatures.FirstOrDefault(a =>
+                            a.flags.HasFlag(CreatureFlags.Archetype) &&
+                            a.Species == c.Species &&
+                            a.name == c.motherName &&
+                            (a.sex == Sex.Female || a.sex == Sex.Unknown));
+                    }
+
+                    mother ??= EnsurePlaceholderCreature(placeholderAncestors, c, c.motherGuid, c.motherName, Sex.Female);
+                }
 
                 Creature father = null;
-                if (c.fatherGuid != Guid.Empty
-                    && !creatureGuids.TryGetValue(c.fatherGuid, out father))
-                    father = EnsurePlaceholderCreature(placeholderAncestors, c, c.fatherGuid, c.fatherName, Sex.Male);
+                if (c.fatherGuid != Guid.Empty && !creatureGuids.TryGetValue(c.fatherGuid, out father))
+                {
+                    // Check for an archetype creature matching by name, species, and sex
+                    if (!string.IsNullOrEmpty(c.fatherName))
+                    {
+                        father = _creatureCollection.creatures.FirstOrDefault(a =>
+                            a.flags.HasFlag(CreatureFlags.Archetype) &&
+                            a.Species == c.Species &&
+                            a.name == c.fatherName &&
+                            (a.sex == Sex.Male || a.sex == Sex.Unknown));
+                    }
+
+                    father ??= EnsurePlaceholderCreature(placeholderAncestors, c, c.fatherGuid, c.fatherName, Sex.Male);
+                }
 
                 c.Mother = mother;
                 c.Father = father;

--- a/ARKBreedingStats/importExported/ImportExported.cs
+++ b/ARKBreedingStats/importExported/ImportExported.cs
@@ -216,12 +216,14 @@ namespace ARKBreedingStats.importExported
                         cv.statValues[Stats.CraftingSpeedMultiplier] = 1 + value;
                         break;
                     case "DinoAncestorsMale":
-                        Regex r = new Regex(@"MaleName=([^;]+);MaleDinoID1=([^;]+);MaleDinoID2=([^;]+);FemaleName=([^;]+);FemaleDinoID1=([^;]+);FemaleDinoID2=([^;]+)");
+                        Regex r = new Regex(@"MaleName=([^;]+) - Lvl \d+;MaleDinoID1=([^;]+);MaleDinoID2=([^;]+);FemaleName=([^;]+) - Lvl \d+;FemaleDinoID1=([^;]+);FemaleDinoID2=([^;]+)");
                         Match m = r.Match(text);
                         if (m.Success)
                         {
                             cv.motherArkId = BuildArkId(m.Groups[5].Value, m.Groups[6].Value);
                             cv.fatherArkId = BuildArkId(m.Groups[2].Value, m.Groups[3].Value);
+                            cv.motherName = m.Groups[4].Value;
+                            cv.fatherName = m.Groups[1].Value;
                             cv.isBred = true;
                         }
                         break;

--- a/ARKBreedingStats/library/Creature.cs
+++ b/ARKBreedingStats/library/Creature.cs
@@ -728,8 +728,13 @@ namespace ARKBreedingStats.Library
         /// </summary>
         Divider = 4096,
         /// <summary>
+        /// When looking for parent stats, allow this creature to match by name.
+        /// This allows a single library creature to represent many in-game creatures.
+        /// </summary>
+        Archetype = 8192,
+        /// <summary>
         /// If applied to the flags with &, the status is removed.
         /// </summary>
-        StatusMask = Mutated | Neutered | Placeholder | Female | Male | MutagenApplied | Divider
+        StatusMask = Mutated | Neutered | Placeholder | Female | Male | MutagenApplied | Divider | Archetype
     }
 }

--- a/ARKBreedingStats/library/CreatureValues.cs
+++ b/ARKBreedingStats/library/CreatureValues.cs
@@ -70,6 +70,10 @@ namespace ARKBreedingStats.Library
         public Guid motherGuid;
         [JsonProperty]
         public Guid fatherGuid;
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string motherName;
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string fatherName;
         private Creature mother;
         private Creature father;
         [JsonProperty]

--- a/ARKBreedingStats/local/strings.resx
+++ b/ARKBreedingStats/local/strings.resx
@@ -1405,4 +1405,11 @@ It's also possible to filter for creatures with a color in one of multiple possi
   <data name="BtBeepNewRegionColor" xml:space="preserve">
     <value>new region color</value>
   </data>
+  <data name="cbArchetype" xml:space="preserve">
+    <value>Archetype</value>
+  </data>
+  <data name="cbArchetypeTT" xml:space="preserve">
+    <value>When looking for parent stats, allow this creature to match by name.
+This allows you to have a single library creature represent many in-game creatures, as long as they're named the same.</value>
+  </data>
 </root>


### PR DESCRIPTION
Allow creatures to be marked as archetypes for name based parent matching (as opposecd to ingame id)

- Add Archetype flag to creature
- Add motherName and fatherName to extracted CreatureValues
- Add archetype lookup before assigning placeholder creature during parent lookup
- Remove naming config button and move naming strategy buttons to a single line to make room for Archetype button

<img width="251" height="57" alt="image" src="https://github.com/user-attachments/assets/bca3e82b-a214-41f6-9935-1521560a0c05" />
