### PR TITLE
fix: apply naming pattern after parent linking in Export Gun listen channel

### DIFF
--- a/ARKBreedingStats/Form1.exportGun.cs
+++ b/ARKBreedingStats/Form1.exportGun.cs
@@ -176,18 +176,27 @@ namespace ARKBreedingStats
 
                 _creatureCollection.DetermineColorStatus(speciesSelector1.SelectedSpecies, creature.colors, out _, out _, out _);
                 DetermineLevelStatusAndSoundFeedback(creature, Properties.Settings.Default.PlaySoundOnAutoImport, Properties.Settings.Default.PlayColorSoundOnAutoImport);
-                SetNameOfImportedCreature(creature, null, out _,
-                        _creatureCollection.creatures.FirstOrDefault(c => c.guid == creature.guid));
+
+                var alreadyExistingCreature = _creatureCollection.creatures.FirstOrDefault(c => c.guid == creature.guid);
 
                 if (addCreature)
                 {
+                    // Merge first so parent linking sees the creature in the collection (consistent with file-import flow in Form1.collection.cs).
+                    _creatureCollection.MergeCreatureList(new[] { creature }, true);
+                    // Resolve parents and recompute the ancestor generation BEFORE applying the naming pattern,
+                    // otherwise tokens like {gena}/{generation} fall back to 0 because creature.Mother/Father are still null.
+                    UpdateParents(new[] { creature });
+                    creature.RecalculateAncestorGenerations();
+
+                    SetNameOfImportedCreature(creature, null, out _, alreadyExistingCreature);
+
                     data.TaskNameGenerated?.SetResult(new ServerSendName { CreatureName = creature.name, ConnectionToken = data.ServerToken, ExportId = data.SendId });
 
-                    _creatureCollection.MergeCreatureList(new[] { creature }, true);
                     UpdateCreatureParentLinkingSort(goToLibraryTab: gotoLibraryTab);
                 }
                 else
                 {
+                    SetNameOfImportedCreature(creature, null, out _, alreadyExistingCreature);
                     SetCreatureValuesLevelsAndInfoToExtractor(creature);
                 }
 


### PR DESCRIPTION
## Summary

The auto-import handler for the Export Gun listen channel (`Form1.exportGun.cs` → `AsbServerDataSent`) was applying the naming pattern and sending the generated name back to the game **before** the imported creature had its parents resolved and its generation recalculated.

As a consequence, every pattern token that depends on the pedigree depth — `{gena}`, `{gen}`, `{nr_in_gen}`, `{nr_in_gen_sex}`, and `{genn}` — was evaluated as if the creature had `generation = 0`. Users had to manually re-apply the naming pattern in ASB (Ctrl+A + Apply pattern) after each Export Gun shot to get the correct generation in the in-game name.

This PR reorders the import flow inside `if (addCreature)` to match the existing file-import flow in `Form1.collection.cs` (which already carries an explicit comment: *"This can only be done after parent linking to get correct name pattern values related to parents"*).

## What changed

In `Form1.exportGun.cs` → `AsbServerDataSent`:

**Before**
1. `SetNameOfImportedCreature(...)` — pattern evaluated with `generation = 0`
2. `data.TaskNameGenerated?.SetResult(...)` — sends back the wrong name
3. `MergeCreatureList(...)`
4. `UpdateCreatureParentLinkingSort(...)` — finally resolves parents

**After**
1. Capture `alreadyExistingCreature` (must happen before the merge, otherwise it ends up pointing at the freshly-added creature)
2. `MergeCreatureList(...)`
3. `UpdateParents(new[] { creature })` — resolves `creature.Mother` / `creature.Father` (creates placeholders for unknown ancestors, consistent with the rest of the code). This is the primary unblocker: `NamePattern.GenerateCreatureName` has a fallback (`generation <= 0` → `Math.Max(Mother?.generation + 1, Father?.generation + 1)`), so once parents are linked, the pattern can already compute the right generation tokens.
4. `creature.RecalculateAncestorGenerations()` — also sets `creature.generation` directly, matching the file-import flow and keeping the value consistent for any downstream consumer.
5. `SetNameOfImportedCreature(...)` — pattern evaluated with the right values
6. `data.TaskNameGenerated?.SetResult(...)` — sends the correctly-generated name
7. `UpdateCreatureParentLinkingSort(...)`

The `else` branch (`addCreature == false`) now also receives the captured `alreadyExistingCreature` for consistency.

## Pre-requisite for the visible effect

The pattern is only applied when one of the auto-import settings is enabled (Settings → Auto Import):
- `Apply name pattern on auto-import: always` (`applyNamePatternOnAutoImportAlways`)
- `Apply name pattern on auto-import: only for new creatures` (`applyNamePatternOnAutoImportForNewCreatures`)
- `Apply name pattern on auto-import: if creature has no name` (`applyNamePatternOnImportIfEmptyName`)

Mentioning this for reviewer convenience — without one of these enabled, the fix's effect won't be visible during manual testing.

## Test plan

- [x] Build with `.\build.ps1` — solution builds, 64/64 unit tests pass.
- [x] Manual smoke test with live ARK session on our ASA cluster — fully functional end-to-end:
  - Auto-import setting `applyNamePatternOnAutoImportAlways = true`
  - Pattern uses `{gena}` as first token
  - Fire Export Gun on bred creatures whose parents are already in the library with `gen > 0` → in-game name now contains the correct `gena` letter (B, C, D, ...) on the first shot, instead of always being `A`
  - Same with parents not yet in library → placeholders are created, `gen = 1` produced as expected
  - Tamed (non-bred) creatures still produce `gen = 0` / `gena = A` as expected
- [x] Same scenario through the file-import path still behaves identically (no regression — the same logic was already there).

## Related ideas (not in this PR, gauging interest)

Two ideas surfaced while debugging — sharing briefly in case they're of interest. Happy to open dedicated discussions before any implementation:

1. **Opt-in auto bulk-rename when a species' top stat flips.** Trigger a recalc + best-effort push of all in-game names for the affected species, with graceful fallback to a "pending rename" flag for cryopodded / offline creatures (the Export Gun mod can't reach a creature without an AActor reference).

2. **Automatic server-rate retrieval via the Export Gun mod.** The mod already supports a `ServerHash` payload — if it could push the current server multipliers (taming/breeding/XP/etc.) automatically on connect or hash change, players would get accurate stat extractions without having to ask the admin. Scope: only the rates the engine needs; naming pattern stays a per-user choice.

Happy to address review feedback or split this PR if preferred.

## Disclaimer

First time contributing to ARK Smart Breeding — happy to align this PR with any project conventions (commit style, branching, formatting) if something doesn't match your usual workflow, and to lend a hand elsewhere if useful.
