### PR TITLE
fix: ServerHash regex off-by-one in listen channel

### DIFF
--- a/ARKBreedingStats/AsbServer/Connection.cs
+++ b/ARKBreedingStats/AsbServer/Connection.cs
@@ -268,7 +268,7 @@ namespace ARKBreedingStats.AsbServer
                         var matchServerHash = RgServerHash.Match(received);
                         if (matchServerHash.Success)
                         {
-                            report = new ProgressReportAsbServer { ServerHash = matchServerHash.Groups[2].Value };
+                            report = new ProgressReportAsbServer { ServerHash = matchServerHash.Groups[1].Value };
 
                             while (true)
                             {


### PR DESCRIPTION
## Summary

The regex `^event: server (\-?\d+)$` captures the hash in `Groups[1]`, but the code reads `Groups[2]`. `ServerHash` is therefore always empty for `event: server` events, which makes `AsbServerDataSent` route the multipliers JSON into the creature-import branch where it fails silently (no `BlueprintPath`) and gets dropped.

@coldino confirmed on #1406 that the mod *is* sending multipliers through the export server — so the mechanism was correct, ASB just wasn't parsing the hash.

## Fix

```diff
- ServerHash = matchServerHash.Groups[2].Value
+ ServerHash = matchServerHash.Groups[1].Value
```

## Test plan

- [x] `.\build.ps1` — builds, 64/64 tests pass.
- [x] Verified on an ASA cluster with custom rates: before the fix Settings → Multipliers stayed at ASA Official defaults despite `event: server` events arriving; after the fix the cluster's actual values (Taming 5x, EggHatch 5x, BabyMature 5x, etc.) auto-apply on the next push from the mod.

> Developed with AI assistance.
> Bug observation, reproduction, build, testing, and integration decisions on my side; 
> AI used for codebase navigation, root cause analysis support, and 
> drafting this PR description.