### PR TITLE
Include Traditional Chinese (zh-TW) in installer

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -80,6 +80,7 @@ Source: "{#ReleaseDir}\pt-BR\*"; DestDir: "{app}\pt-BR\"; Excludes: "*.pdb,*.xml
 Source: "{#ReleaseDir}\ru\*"; DestDir: "{app}\ru\"; Excludes: "*.pdb,*.xml"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#ReleaseDir}\tr\*"; DestDir: "{app}\tr\"; Excludes: "*.pdb,*.xml"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#ReleaseDir}\zh\*"; DestDir: "{app}\zh\"; Excludes: "*.pdb,*.xml"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "{#ReleaseDir}\zh-TW\*"; DestDir: "{app}\zh-TW\"; Excludes: "*.pdb,*.xml"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#ReleaseDir}\_manifest.json"; DestDir: "{localappdata}\{#AppName}\"; Flags: ignoreversion
 Source: "{#ReleaseDir}\json\*.json"; DestDir: "{localappdata}\{#AppName}\json\"; Flags: ignoreversion
 Source: "{#ReleaseDir}\json\*.txt"; DestDir: "{localappdata}\{#AppName}\json\"; Flags: ignoreversion


### PR DESCRIPTION
## Problem

The Traditional Chinese translation (`ARKBreedingStats/local/strings.zh-tw.resx`) and the language option (`繁體中文` → `zh-tw`) both exist, but Traditional Chinese is missing from the released **installer**.

The cause is in `setup.iss`: the `[Files]` section lists each language satellite folder one by one (`de`, `es`, `fr`, `it`, `ja`, `pl`, `pt-BR`, `ru`, `tr`, `zh`). The top-level `Source: "{#ReleaseDir}\*"` entry has no `recursesubdirs`, so each language subfolder needs its own line — and the `zh-TW` line was never added. As a result the `dotnet publish` output's `zh-TW\` satellite assembly is never copied into the installer.

(The zip artifact is unaffected, since `Compress-Archive` packs the publish directory recursively.)

## Fix

Add the missing `zh-TW` folder line alongside the other languages in `setup.iss`, with the same `skipifsourcedoesntexist` flag as the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)